### PR TITLE
Add Buster support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-DEBIAN_BOXES= stretch
+DEBIAN_BOXES= buster stretch
 UBUNTU_BOXES= xenial
 TODAY=$(shell date -u +"%Y-%m-%d")
 

--- a/README.md
+++ b/README.md
@@ -25,13 +25,12 @@ project which this was forked from.
 
 ## Building the boxes
 
-_In order to build the boxes you need to have the `lxc-download`
+In order to build the boxes you need to have the `lxc-download`
 template available on your machine (note: the `lxc` package included
-in Debian 10 satisfies this requirement). If you don't have one
-present, please create one based on
+in Debian 10 satisfies this requirement). Create one based on
 [this](https://github.com/lxc/lxc/blob/master/templates/lxc-download.in)
-and drop it on your lxc templates path (usually
-`/usr/share/lxc/templates/`)._
+template if required, and drop it on your lxc templates path (usually
+`/usr/share/lxc/templates/`).
 
 ```sh
 git clone https://github.com/sitepoint/vagrant-lxc-base-boxes.git
@@ -46,12 +45,12 @@ ADDPACKAGES="aptitude htop" \
 make xenial
 ```
 
-Will build a Ubuntu Xenial x86_64 box with aptitude and htop as
-additional packages pre-installed. You can also specify the packages
-in a file xenial_packages.
+The above command will build a Ubuntu Xenial x86\_64 box with aptitude
+and htop as additional packages pre-installed. You can also specify
+the packages in a file xenial\_packages.
 
-Unwanted packages can also be removed via the REMPACKAGES variable
-should the lxc-download template pull in something undesirable.
+Unwanted packages can be removed via the REMPACKAGES variable should
+the lxc-download template try to pull in something undesirable.
 
 
 ## Pre built base boxes

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ _**NOTE:** None of the base boxes below have a provisioner pre-installed_
 
 | Distribution | VagrantCloud box |
 | ------------ | ---------------- |
+| Debian Buster 10 x86_64 | [debian-buster-amd64](https://app.vagrantup.com/sitepoint/boxes/debian-buster-amd64) |
 | Debian Stretch 9 x86_64 | [debian-stretch-amd64](https://app.vagrantup.com/sitepoint/boxes/debian-stretch-amd64) |
 | Ubuntu Xenial 16.04 x86_64 | [ubuntu-xenial-amd64](https://app.vagrantup.com/sitepoint/boxes/ubuntu-xenial-amd64) |
 

--- a/common/download.sh
+++ b/common/download.sh
@@ -35,7 +35,7 @@ utils.lxc.create -t download -- \
     --release ${RELEASE} \
     --arch ${ARCH}
 if [ ${UID} -eq 0 ] &&
-    [ ${DISTRIBUTION} = 'debian' -a ${RELEASE} = 'stretch' ]
+    [ ${DISTRIBUTION} = 'debian' ]
 then
     # Improve systemd support:
     # - The debian template does it but the debian image from the download


### PR DESCRIPTION
It's about time!

![image](https://user-images.githubusercontent.com/250531/95819765-7547ba80-0d72-11eb-87b8-2d2422a274fa.png)

I've noticed a couple of bugs in `debian/vagrant-lxc-fixes.sh` related to parsing `sed` commands as arguments to `utils.lxc.attach` which I couldn't immediately figure out, which I'll have to fix up later.